### PR TITLE
Explicity cast uv_plane_len as int

### DIFF
--- a/uvc.pyx
+++ b/uvc.pyx
@@ -166,7 +166,7 @@ cdef class Frame:
             Y = np.asarray(self._yuv_buffer[:y_plane_len]).reshape(self.height,self.width)
 
             if self.yuv_subsampling == turbojpeg.TJSAMP_422:
-                uv_plane_len = y_plane_len/2
+                uv_plane_len = y_plane_len//2
                 offset = y_plane_len
                 U = np.asarray(self._yuv_buffer[offset:offset+uv_plane_len]).reshape(self.height,self.width/2)
                 offset += uv_plane_len
@@ -175,7 +175,7 @@ cdef class Frame:
                 U = U[::2,:]
                 V = V[::2,:]
             elif self.yuv_subsampling == turbojpeg.TJSAMP_420:
-                uv_plane_len = y_plane_len/4
+                uv_plane_len = y_plane_len//4
                 offset = y_plane_len
                 U = np.asarray(self._yuv_buffer[offset:offset+uv_plane_len]).reshape(self.height/2,self.width/2)
                 offset += uv_plane_len
@@ -206,7 +206,7 @@ cdef class Frame:
             Y = np.asarray(self._yuv_buffer[:y_plane_len]).reshape(self.height,self.width)
 
             if self.yuv_subsampling == turbojpeg.TJSAMP_422:
-                uv_plane_len = int(y_plane_len/2)
+                uv_plane_len = y_plane_len//2
                 offset = y_plane_len
                 U = np.asarray(self._yuv_buffer[offset:offset+uv_plane_len]).reshape(self.height,self.width/2)
                 offset += uv_plane_len

--- a/uvc.pyx
+++ b/uvc.pyx
@@ -206,7 +206,7 @@ cdef class Frame:
             Y = np.asarray(self._yuv_buffer[:y_plane_len]).reshape(self.height,self.width)
 
             if self.yuv_subsampling == turbojpeg.TJSAMP_422:
-                uv_plane_len = y_plane_len/2
+                uv_plane_len = int(y_plane_len/2)
                 offset = y_plane_len
                 U = np.asarray(self._yuv_buffer[offset:offset+uv_plane_len]).reshape(self.height,self.width/2)
                 offset += uv_plane_len


### PR DESCRIPTION
`y_plane_len/2` results in float. We could also use `//` here because both args are `int` - but to be safe we can be explicit with `int()`

Fixes: https://github.com/pupil-labs/pupil/issues/617

However in Pupil Capture we will see a runtime warning when recording with this mode:

```
/pupil/pupil_src/shared_modules/av_writer.py:130: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  y,u,v = input_frame.yuv422
```