### PR TITLE
Set explicit build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes an issue when installing the module in en virtual env with `--system-site-packages` enabled.