### PR TITLE
Refactor paths loading in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,16 @@ if platform.system() == "Windows":
     cmake_args.append(f"-DPTHREADS_WIN_INCLUDE_DIR='{ptw.include_path}'")
     cmake_args.append(f"-DPTHREADS_WIN_IMPORT_LIB_PATH='{ptw.import_lib_path}'")
 
+    paths = {}
     paths_loc = os.environ.get("DEPS_PATHS_LOC")
-    paths = json.loads(pathlib.Path(paths_loc).read_text())
+
+    if paths_loc:
+        paths = json.loads(pathlib.Path(paths_loc).read_text())
+
     for path_name, path_value in paths.items():
         path_value = pathlib.Path(path_value).resolve()
         cmake_args.append(f"-D{path_name}='{path_value}'")
+
 
     # The Ninja cmake generator will use mingw (gcc) on windows travis instances, but we
     # need to use msvc for compatibility. The easiest solution I found was to just use


### PR DESCRIPTION
Refactor paths loading to check if paths_loc is set before loading.  On windnows I was recieving error:

ERROR: Failed to build 'file:///C:/Users/micha/OneDrive/Eye%20Tracking/pyuvc' when getting requirements to build editable

This resolves the issue on win11 with python 3.11